### PR TITLE
Improve binding on login component

### DIFF
--- a/src/components/login-component.html
+++ b/src/components/login-component.html
@@ -4,8 +4,9 @@
   <div sp-show="state | is 'authenticated'">You are authenticated</div>
   <form sp-show="state | in 'ready,login_error'">
     <div sp-each-field="fields">
-      <label for="#login-field-{field.name}">{field.label}</label>
-      <input sp-type="field.type"
+      <label sp-for="field.name | prefix 'login-field-'">{field.label}</label>
+      <input sp-id="field.name | prefix 'login-field-'"
+             sp-type="field.type"
              sp-name="field.name"
              sp-value="field.value"
              sp-placeholder="field.placeholder"

--- a/src/stormpath.js
+++ b/src/stormpath.js
@@ -70,6 +70,7 @@ class Stormpath extends EventEmitter {
     Rivets.formatters['in'] = (a, b) => (b || '').split(',').indexOf(a) !== -1;
 
     Rivets.binders.required = (el, val) => el.required = val === true;
+    Rivets.formatters.prefix = (name, prefix) => prefix + name;
 
     for (var id in templates) {
       const options = templates[id];


### PR DESCRIPTION
Added binding for `placeholder`, `required`, `id`, etc.

`id` and `for` required a new formatter because doing interpolation/expressions isn't supported in the binding syntax.