### PR TITLE
Add karma + mocha tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,7 +6,7 @@ module.exports = function (config) {
     webpack: require('./webpack.config'),
     reporters: ['progress'],
     preprocessors: {
-      './test/**/*.js': ['webpack']
+      './test/**/*.js': ['webpack', 'sourcemap']
     },
     port: 9876,
     colors: true,
@@ -17,7 +17,8 @@ module.exports = function (config) {
     plugins: [
       require('karma-webpack'),
       'karma-mocha',
-      'karma-phantomjs-launcher'
+      'karma-phantomjs-launcher',
+      'karma-sourcemap-loader'
     ],
     webpackMiddleware: {
       noInfo: true

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "karma": "^1.3.0",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.2",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.8.0",
     "mocha": "^3.2.0",
     "webpack-dev-middleware": "^1.8.4"

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,0 @@
-import assert from 'assert';
-
-describe('tests', () => {
-  it('should test things', () => {
-    assert.equal(true, true);
-  });
-});

--- a/test/stormpath.js
+++ b/test/stormpath.js
@@ -1,0 +1,8 @@
+import Stormpath from '../src';
+import assert from 'assert';
+
+describe('Stormpath', () => {
+  it('should be a constructor', () => {
+    assert.equal(typeof Stormpath, 'function');
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
 
 module.exports = {
-  devtool: 'cheap-module-eval-source-map',
+  devtool: 'inline-source-map',
 
   output: {
     library: 'Stormpath'


### PR DESCRIPTION
Added karma runner and mocha tests (written in ES6).

To test the sample test:

```term
$ npm i
$ karma start
```

If you don't have karma installed globally, you can instead run

```term
$ ./node_modules/karma/bin/karma start
```

Fixes #9.