### PR TITLE
Break out karma runner, npm test should run everything

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
   "scripts": {
     "build": "NODE_ENV=production webpack src/index.js dist/stormpath.js --display-modules && NODE_ENV=production webpack -p src/index.js dist/stormpath.min.js --display-modules",
     "dev": "node dev-server.js",
+    "karma": "./node_modules/karma/bin/karma start",
+    "karma:watch": "npm run karma -- --no-single-run --auto-watch",
     "lint": "./node_modules/.bin/esw -c .eslintrc src test",
     "lint:watch": "npm run lint -- --watch",
-    "test": "./node_modules/karma/bin/karma start",
-    "test:watch": "npm run test -- --no-single-run --auto-watch"
+    "test": "npm run lint && npm run karma"
   },
   "dependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
`npm test` should be the de-facto “everything passes” exit, so it needs to run the linter, and eventually the protractor tests as well.

`npm karma:watch` can be used for auto-testing when developing locally

`npm test` should be run before pushing, although travis will run it as well