### PR TITLE
add meta viewport declarations for mobile friendlyness

### DIFF
--- a/example/login/index.html
+++ b/example/login/index.html
@@ -6,6 +6,7 @@
 <html lang="en" class="no-js"><!--<![endif]-->
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
     <title>Stormpath Widget - Login Example</title>
     <script src="/js/app.js"></script>
     <script>


### PR DESCRIPTION
FYI @nbarbettini - you can use the device emulator in chrome to see the difference:

![image](https://cloud.githubusercontent.com/assets/132343/21410208/c9dea4f6-c793-11e6-994e-827a58b51bc8.png)
