### PR TITLE
Stop browser autocomplete on unmasked password

### DIFF
--- a/src/components/form-fields/password-form-field.js
+++ b/src/components/form-fields/password-form-field.js
@@ -20,10 +20,12 @@ class PasswordFormFieldComponent extends FormFieldComponent {
     }
 
     if (passwordFieldElement.type === 'password') {
-      passwordFieldElement.type = 'text';
+      passwordFieldElement.setAttribute('type', 'text');
+      passwordFieldElement.setAttribute('autocomplete', 'off');
       toggleElement.innerHTML = 'Hide';
     } else {
-      passwordFieldElement.type = 'password';
+      passwordFieldElement.removeAttribute('autocomplete');
+      passwordFieldElement.setAttribute('type', 'password');
       toggleElement.innerHTML = 'Show';
     }
 


### PR DESCRIPTION
Closes #62

Uses `autocomplete="off"` as described [here](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion). Not [guaranteed](http://caniuse.com/#search=autocomplete) to work in all browsers, but I confirmed it works in Chrome latest, Firefox latest, Safari latest, and IE11.