### PR TITLE
Dynamic disabling of features

### DIFF
--- a/src/components/login/login.html
+++ b/src/components/login/login.html
@@ -23,7 +23,7 @@
 
     <fieldset class="sp-form-group">
       <sp-form-fields fields="fields" name-prefix="'sp-form-login'"></sp-form-fields>
-      <a rv-on-click="viewManager.showForgotPassword">Forgot password?</a>
+      <a rv-show="props.canRequestPasswordReset" rv-on-click="viewManager.showForgotPassword">Forgot password?</a>
     </fieldset>
 
     <div class="sp-form-group">
@@ -31,6 +31,6 @@
     </div>
 
     <hr>
-    <span class="sp-light">Don't have an account?</span> <a class="sp-right" rv-on-click="viewManager.showRegistration">Sign up</a>
+    <span rv-show="props.canRegister" class="sp-light">Don't have an account?</span> <a class="sp-right" rv-on-click="viewManager.showRegistration">Sign up</a>
   </form>
 </div>

--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -19,6 +19,8 @@ class LoginComponent {
     showButtons: LoginComponent.maxInitialButtons,
     showMoreButton: false,
     isSubmitting: false,
+    canRegister: false,
+    canRequestPasswordReset: false,
   };
 
   constructor(data) {
@@ -45,6 +47,15 @@ class LoginComponent {
       this.userService.getLoginViewModel()
         .then(this.onViewModelLoaded.bind(this))
         .catch(this.onError.bind(this, 'loading_error'));
+
+      this.userService.getRegistrationViewModel()
+        .then(() => this.props.canRegister = true)
+        .catch(() => this.props.canRegister = false);
+
+      // If we get a 405 from this endpoint on Client API, it means that it is
+      // enabled on Client API.  If it 404's, it is not enabled.
+      this.userService.getForgotEndpointResponse()
+        .catch((err) => this.props.canRequestPasswordReset = err.status === 405);
     });
   }
 

--- a/src/data/user/cached-user-service.js
+++ b/src/data/user/cached-user-service.js
@@ -33,6 +33,10 @@ class CachedUserService {
     });
   }
 
+  getForgotEndpointResponse() {
+    return this._cachedPromise('forgot-endpoint-response', () => this.userService.getForgotEndpointResponse());
+  }
+
   getLoginViewModel() {
     return this._cachedPromise('login-view', () => this.userService.getLoginViewModel());
   }

--- a/src/data/user/client-api-user-service.js
+++ b/src/data/user/client-api-user-service.js
@@ -91,6 +91,10 @@ class ClientApiUserService extends EventEmitter {
     });
   }
 
+  getForgotEndpointResponse() {
+    return this.httpProvider.getJson('/forgot');
+  }
+
   getLoginViewModel() {
     return this.httpProvider.getJson('/login');
   }

--- a/src/stormpath.js
+++ b/src/stormpath.js
@@ -96,8 +96,14 @@ class Stormpath extends EventEmitter {
   }
 
   _preloadViewModels() {
-    this.userService.getLoginViewModel();
-    this.userService.getRegistrationViewModel();
+    this.userService.getLoginViewModel().catch(() => {});
+    this.userService.getRegistrationViewModel().catch(() => {});
+    this.userService.getForgotEndpointResponse().catch(() => {});
+  }
+
+  _handleDisabledEndpoint(name, uri) {
+    /* eslint-disable no-console */
+    console.error(name + ' endpoint could not be loaded.  Ensure that the ' + uri + ' is enabled on the provided Client API domain, or on your local server if not using Client API.');
   }
 
   _handleCallbackResponse() {
@@ -149,11 +155,15 @@ class Stormpath extends EventEmitter {
   }
 
   showLogin() {
-    return this.viewManager.showLogin();
+    this.userService.getLoginViewModel()
+      .then(this.viewManager.showLogin.bind(this.viewManager))
+      .catch(this._handleDisabledEndpoint.bind(null, 'Login', '/login'));
   }
 
   showRegistration() {
-    return this.viewManager.showRegistration();
+    this.userService.getRegistrationViewModel()
+      .then(this.viewManager.showRegistration.bind(this.viewManager))
+      .catch(this._handleDisabledEndpoint.bind(null, 'Registration', '/register'));
   }
 
   showEmailVerification(token) {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,7 +1,7 @@
 var webpack = require('webpack');
 
 module.exports = {
-  devtool: 'cheap-module-eval-source-map',
+  devtool: 'source-map',
 
   entry: [
     './src/index'


### PR DESCRIPTION
This PR addresses most of the concerns in #36 , anything not addressed here I am declaring as out-of-scope for the 0.0.1 milestone.

* Remove link to “forgot password” if that endpoint is disabled, determined by 405 to mean “this is on, you just can’t make a GET request to it”.  This is very specific to Client API and won’t work with framework integrations

* Provide errors to the developer if they try to show login or registration, if were were unable to fetch view models for those features.  We error, and do not try to show the modal.

* This does not address the disabling of the /change or /verify endpoints, those are tricky because 404's there can mean "invalid token" or "this is disabled".  We wil have to address these issues at a later date with some new design.

* Change the source maps configuration, this new values produces better source maps (they preserve function names up the call stack).