### PR TITLE
Output to widget/major.x

### DIFF
--- a/package-for-dist.js
+++ b/package-for-dist.js
@@ -50,8 +50,8 @@ fs.writeFileSync(`${latestDirectory}/${sourceFilename}`, source, { encoding: 'ut
 console.log(`Copying sourcemap to ${latestDirectory}/${sourceMapFilename}`);
 fs.writeFileSync(`${latestDirectory}/${sourceMapFilename}`, sourceMap, { encoding: 'utf-8' });
 
-// Push tagged minor releases to /widget/x.y/
-const shortVersion = `${semver.major(tag)}.${semver.minor(tag)}`;
+// Push tagged minor releases to /widget/major.x/
+const shortVersion = `${semver.major(tag)}.x`;
 const shortVersionDirectory = `${stagingDirectory}/${shortVersion}`;
 fs.mkdirSync(shortVersionDirectory);
 console.log(`Copying source to ${shortVersionDirectory}/${sourceFilename}`);
@@ -59,7 +59,7 @@ fs.writeFileSync(`${shortVersionDirectory}/${sourceFilename}`, source, { encodin
 console.log(`Copying sourcemap to ${shortVersionDirectory}/${sourceMapFilename}`);
 fs.writeFileSync(`${shortVersionDirectory}/${sourceMapFilename}`, sourceMap, { encoding: 'utf-8' });
 
-// Push tagged releases to /widget/x.y.z/
+// Push tagged releases to /widget/major.minor.patch/
 const versionDirectory = `${stagingDirectory}/${tag}`;
 fs.mkdirSync(versionDirectory);
 console.log(`Copying source to ${versionDirectory}/${sourceFilename}`);


### PR DESCRIPTION
Updates the CDN staging script to output tagged releases to `/widget/{major}.x`. For example:

```
tag 0.0.1  ->  /widget/0.x/stormpath.min.js
tag 1.1.0  ->  /widget/1.x/stormpath.min.js
```

Closes #100 