### PR TITLE
Emit error when social provider callback error is present

### DIFF
--- a/example/login/index.html
+++ b/example/login/index.html
@@ -95,7 +95,7 @@
         });
 
         stormpath.on('loginError', function (error) {
-          console.log('An error occured during social login: ', error);
+          console.error(error);
         });
 
         initializeView(stormpath);

--- a/src/stormpath.js
+++ b/src/stormpath.js
@@ -47,7 +47,6 @@ class Stormpath extends EventEmitter {
     options.authStrategy = AuthStrategy.resolve(options.authStrategy, options.appUri);
     this.userService = this._createUserService(options.authStrategy, options.appUri);
 
-    this._handleSocialProviderCallbackError();
     this._initializeUserServiceEvents();
     this._preloadViewModels();
 
@@ -66,18 +65,6 @@ class Stormpath extends EventEmitter {
 
   static getInstance() {
     return Stormpath.instance;
-  }
-
-  _handleSocialProviderCallbackError() {
-    const parsedQueryString = utils.parseQueryString(window.location.search);
-    const errorCode = parsedQueryString.error;
-    const errorDescription = parsedQueryString.error_description;
-
-    if (errorCode && errorDescription) {
-      const socialProviderError = new Error('Social provider callback error (' + errorCode + '): ' + errorDescription);
-      socialProviderError.error = errorCode;
-      this.emit('error', socialProviderError);
-    }
   }
 
   _createUserService(authStrategy, appUri) {
@@ -126,11 +113,12 @@ class Stormpath extends EventEmitter {
 
   _handleCallbackResponse() {
     const parsedQueryString = utils.parseQueryString(utils.getWindowQueryString());
+    const error = parsedQueryString.error;
+    const error_description = parsedQueryString.error_description;
 
-    if (parsedQueryString.error || parsedQueryString.error_description) {
-      // TODO: Render human-readable errors in UI somewhere...
-      // The full list of error codes is here: https://tools.ietf.org/html/rfc6749#section-4.1.2.1
-      this.emit('loginError', parsedQueryString.error);
+    if (error) {
+      const errorMessage = 'Provider Callback Error: ' + error + (error_description ? (' (' + error_description + ')') : '');
+      this.emit('loginError', new Error(errorMessage));
     }
 
     const assertionToken = parsedQueryString.jwtResponse;

--- a/src/utils.js
+++ b/src/utils.js
@@ -134,7 +134,6 @@ class Utils {
       }
 
       try {
-        value = (value || '').replace(/\+/gim, '%20'); // Convert + to %20.
         value = decodeURIComponent(value);
       } catch (e) {
         value = undefined;


### PR DESCRIPTION
Fixes #53.

#### Notes

Does not do a `console.error` since emitting an `error` event that is unhandled, automatically ends up as a throw.