### PR TITLE
Add hash to SauceLabs build name

### DIFF
--- a/test/protractor/protractor.conf.sauce.js
+++ b/test/protractor/protractor.conf.sauce.js
@@ -10,7 +10,7 @@ delete baseConfig.capabilities;
 
 baseConfig.sauceBuild = baseConfig.pkg.name;
 
-if (process.env.TRAVIS_PULL_REQUEST) {
+if (process.env.TRAVIS_PULL_REQUEST !== 'false') {
   baseConfig.sauceBuild += ` (travis PR ${process.env.TRAVIS_PULL_REQUEST})`;
 } else if (process.env.TRAVIS_COMMIT) {
   baseConfig.sauceBuild += ` (travis commit ${process.env.TRAVIS_COMMIT})`;


### PR DESCRIPTION
Builds in SauceLabs will now be distinguishable via either the commit hash (if testing on travis), or your machine name (if testing locally).

<img width="671" alt="screen shot 2017-02-03 at 7 12 16 pm" src="https://cloud.githubusercontent.com/assets/7525482/22615214/10476c6a-ea45-11e6-984f-f6b9e9d873d6.png">
