### PR TITLE
Heroku setup + Social callback fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Add beautiful login, registration, and multi-factor authentication screens to your app in only a few lines of code!  To get started, please signup for a free developer account at https://api.stormpath.com/register.
 
+> :racehorse: &nbsp;To see a live demo, please visit https://stormpath-widget.herokuapp.com :racehorse:
+
 ## Table of contents
 
 - [Installation](#installation)
@@ -10,6 +12,7 @@ Add beautiful login, registration, and multi-factor authentication screens to yo
 - [Reference](#reference)
   - [API](#api)
   - [Events](#events)
+
 
 ## Installation
 
@@ -32,6 +35,8 @@ The widget uses the [Stormpath Client API][] to authenticate the user.  Every St
 You will need to tell Stormpath where your front-end application is running, by adding it's domain to the list of **Authorized Origin URIs** on your Stormpath Application.  This can be done from the Stormpath Admin Console.  For example, if you are developing on a local sever that runs your front-end app at `http://localhost:3000`, you need to add that URI to the list
 
 If this is not done, you will see the error `Origin 'http://localhost:3000' is therefore not allowed access.` in the browser error log.
+
+If you will be using social login, you will also need to add this URI to the list of **Authorized Callback URIs**, otherwise you will see the error `Specified redirect_uri is not in the application's configured authorized callback uri's.` when you attempt social login.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The widget uses the [Stormpath Client API][] to authenticate the user.  Every St
 </script>
 ```
 
+You will need to tell Stormpath where your front-end application is running, by adding it's domain to the list of **Authorized Origin URIs** on your Stormpath Application.  This can be done from the Stormpath Admin Console.  For example, if you are developing on a local sever that runs your front-end app at `http://localhost:3000`, you need to add that URI to the list
+
+If this is not done, you will see the error `Origin 'http://localhost:3000' is therefore not allowed access.` in the browser error log.
+
 ## Usage
 
 > :bulb: To see a full code example, check out our [example application](example/index.html).

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "protractor-update": "node ./node_modules/protractor/bin/webdriver-manager update",
     "protractor-local": "./node_modules/protractor/bin/protractor test/protractor/entry-local.js",
     "protractor-sauce": "./node_modules/protractor/bin/protractor test/protractor/entry-sauce.js",
+    "start": "node dev-server.js",
     "test": "npm run lint && npm run karma",
     "pack": "node package-for-dist.js"
   },

--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -75,6 +75,10 @@ class LoginComponent {
   onViewModelLoaded(data) {
     this.fields = data.form.fields;
     this.accountStores = this._onlySupportedAccountStores(data.accountStores);
+    this.accountStores.map((accountStore) => {
+      accountStore.authorizeUri += '&redirect_uri=' + utils.getCurrentHost();
+      return accountStore;
+    });
 
     this.props.smallButtons = this.accountStores.length > 1;
     this.props.showMoreButton = this.accountStores.length > LoginComponent.maxInitialButtons;

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,6 +98,12 @@ class Utils {
     return true;
   }
 
+  getCurrentHost() {
+    return window.location.protocol
+      + '//'
+      + window.location.host;
+  }
+
   getWindowQueryString() {
     return window.location.search;
   }


### PR DESCRIPTION
* Use the current domain as the callback uri.  In the future we need to give the developer a way to override these parameters for the authorize uris
* Updated readme with more configuration needs (authorized origins and callback uris), and include link to new heroku demo