### PR TITLE
Improve example by using jQuery

### DIFF
--- a/example/example.css
+++ b/example/example.css
@@ -152,7 +152,7 @@ a.pure-button-primary {
 .loader {
   color: #ffffff;
   text-indent: -9999em;
-  margin: 15px auto;
+  margin: 30px auto;
   position: relative;
   font-size: 8px;
   -webkit-transform: translateZ(0);

--- a/example/index.html
+++ b/example/index.html
@@ -9,63 +9,50 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/pure-min.css" integrity="sha384-UQiGfs9ICog+LwheBSRCt1o5cbyKIHbwjWscjemyBMT9YCUMZffs6UqUTd0hObXD" crossorigin="anonymous">
+
     <!--[if lte IE 8]>
-        <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/grids-responsive-old-ie-min.css">
+      <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/grids-responsive-old-ie-min.css">
     <![endif]-->
     <!--[if gt IE 8]><!-->
-        <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/grids-responsive-min.css">
+      <link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/grids-responsive-min.css">
     <!--<![endif]-->
     <link rel="stylesheet" href="example.css">
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 
     <!-- Include a reference to the Stormpath Widget -->
     <script src="https://cdn.stormpath.io/widget/0.x/stormpath.min.js"></script>
 
     <!-- Include code to activate the widget when you click specific buttons -->
     <script>
-      function onDocumentReady() {
-
+      $(function () {
         // Initialize Stormpath, you must provide the location of your Client API Domain.
-
-        var stormpath = new Stormpath({
+        window.stormpath = new Stormpath({
           appUri: 'YOUR_CLIENT_API_DOMAIN'
         });
 
         console.log('Loaded Stormpath v%s.', Stormpath.version);
 
-        // Get references to the DOM nodes that we will manipulate once we know
-        // the authentication state.
-
-        var accessTokenContainer = document.getElementById('access-token');
-        var authenticatedContainer = document.getElementById('authenticated');
-        var unauthenticatedContainer = document.getElementById('unauthenticated');
-        var loadingIndicator = document.getElementById('loading-indicator');
-        var loginButton = document.getElementById('login-button');
-        var logoutButton = document.getElementById('logout-button');
-        var signupButton = document.getElementById('signup-button');
-
-        // Hide everything until we know if the user is logged in or not
-
-        authenticatedContainer.style.display = 'none';
-        unauthenticatedContainer.style.display = 'none';
+        // Hide everything until we know if the user is logged in or not.
+        $('#authenticated').hide();
+        $('#unauthenticated').hide();
 
         // Setup some click handlers, so that we can invoke the Stormpath widget
         // when the user clicks the buttons in our application.
-
-        loginButton.addEventListener('click', function () {
+        $('#login-button').click(function () {
           stormpath.showLogin();
         });
 
-        signupButton.addEventListener('click', function () {
+        $('#signup-button').click(function () {
           stormpath.showRegistration();
         });
 
-        logoutButton.addEventListener('click', function () {
+        $('#logout-button').click(function () {
           stormpath.logout();
         });
 
         // These handlers watch the URL for email verification of password reset
         // links, and triggers those flows with the Widget.
-
         if ((/#verify/).test(window.location.href)) {
           stormpath.showEmailVerification();
         }
@@ -76,53 +63,42 @@
 
         // Now we setup our event handlers, to respond to the authentication
         // state that Stormpath provides.
-
         stormpath.on('authenticated', function () {
-
           // This event is fired once we know that the user is authenticated,
           // this can fire on login, or on page reload when the user is already
           // logged in.
-
           console.log('We\'re authenticated!');
 
           // Hide the Stormpath widget
-
           stormpath.remove();
 
-          // Hide our loading indicator, and show the authenticated state
+          // Show the authenticated state.
+          $('#authenticated').show();
+          $('#unauthenticated').hide();
 
-          loadingIndicator.style.display = 'none';
-          authenticatedContainer.style.display = 'block';
-          unauthenticatedContainer.style.display = 'none';
-
-          // Get the user's account so that we can show them their name
-
+          // Get the user's account so that we can show them their name.
           stormpath.getAccount().then(function (account) {
-            document.getElementById('account-full-name').innerHTML = account.givenName;
+            $('#account-full-name').text(account.givenName);
           });
 
-          // Get the user's current access token and show it
-
+          // Get the user's current access token and show it.
           stormpath.getAccessToken().then(function (accessToken) {
             if (!accessToken) {
               accessToken = '(none, in cookie mode)';
             }
 
-            accessTokenContainer.innerHTML = accessToken;
+            $('#access-token').text(accessToken);
           });
         });
 
         stormpath.on('unauthenticated', function () {
-
           // This event is fired once Stormpath has determined that the user is
-          // not logged in.  In this case we show our Login and Signup buttons.
-
+          // not logged in. In this case we show our Login and Signup buttons.
           console.log('We\'re not authenticated. Showing login/registration options.');
 
-          loadingIndicator.style.display = 'none';
-          authenticatedContainer.style.display = 'none';
-          unauthenticatedContainer.style.display = 'block';
-
+          // Show the unauthenticated state.
+          $('#authenticated').hide();
+          $('#unauthenticated').show();
         });
 
         stormpath.on('forgotPasswordSent', function (data) {
@@ -148,25 +124,19 @@
         stormpath.on('loginError', function (error) {
           console.error(error);
         });
-      }
-
-      window.onload = onDocumentReady;
+      });
     </script>
   </head>
-
   <body>
     <div class="header">
-        <div class="home-menu pure-menu pure-menu-horizontal pure-menu-fixed">
-            <a class="pure-menu-heading" href="">Demo</a>
-        </div>
+      <div class="home-menu pure-menu pure-menu-horizontal pure-menu-fixed">
+        <a class="pure-menu-heading" href="">Demo</a>
+      </div>
     </div>
 
     <div class="content-wrapper">
       <div class="content">
-
         <h1 class="splash-head">Stormpath Widget</h1>
-
-        <div class="loader" id="loading-indicator">Loading...</div>
 
         <!-- This div will be shown when the user is logged in. The widget's 'authenticated' event will show or hide it. -->
         <div id="authenticated">
@@ -178,6 +148,7 @@
             This is your access token:
           </p>
           <p id="access-token" class="content"></p>
+
           <p>
             <a id="logout-button" class="pure-button pure-button-primary">Log out</a>
           </p>
@@ -197,8 +168,7 @@
     </div>
 
     <div class="footer">
-        View the source of this page to learn how it's done! Layout by <a href="https://purecss.io">Pure CSS</a>.
+      View the source of this page to learn how it's done! Layout by <a href="https://purecss.io">Pure CSS</a>.
     </div>
-
   </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -63,18 +63,17 @@
 
         // Now we setup our event handlers, to respond to the authentication
         // state that Stormpath provides.
+
         stormpath.on('authenticated', function () {
           // This event is fired once we know that the user is authenticated,
           // this can fire on login, or on page reload when the user is already
           // logged in.
           console.log('We\'re authenticated!');
 
-          // Hide the Stormpath widget
-          stormpath.remove();
-
           // Show the authenticated state.
           $('#authenticated').show();
           $('#unauthenticated').hide();
+          $('#loading-indicator').hide();
 
           // Get the user's account so that we can show them their name.
           stormpath.getAccount().then(function (account) {
@@ -99,6 +98,7 @@
           // Show the unauthenticated state.
           $('#authenticated').hide();
           $('#unauthenticated').show();
+          $('#loading-indicator').hide();
         });
 
         stormpath.on('forgotPasswordSent', function (data) {
@@ -137,6 +137,8 @@
     <div class="content-wrapper">
       <div class="content">
         <h1 class="splash-head">Stormpath Widget</h1>
+
+        <div class="loader" id="loading-indicator">Loading...</div>
 
         <!-- This div will be shown when the user is logged in. The widget's 'authenticated' event will show or hide it. -->
         <div id="authenticated">


### PR DESCRIPTION
Improves the example by refactoring some of the code using jQuery. Also aims at making code more local, duplicating some code as a trade off for readability (easier for beginners to follow code up to down).

Also removed loader since that wasn't being used.