### PR TITLE
Refactor account store transform to single place

### DIFF
--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -57,10 +57,6 @@ class LoginComponent {
     });
   }
 
-  _onlySupportedAccountStores(stores) {
-    return stores.filter((store) => store.authorizeUri);
-  }
-
   toggleMore(e, model) {
     model.props.showMoreButton = false;
     model.props.showButtons = 99;
@@ -74,12 +70,7 @@ class LoginComponent {
 
   onViewModelLoaded(data) {
     this.fields = data.form.fields;
-    this.accountStores = this._onlySupportedAccountStores(data.accountStores);
-    this.accountStores.map((accountStore) => {
-      accountStore.authorizeUri += '&redirect_uri=' + utils.getCurrentHost();
-      return accountStore;
-    });
-
+    this.accountStores = data.accountStores;
     this.props.smallButtons = this.accountStores.length > 1;
     this.props.showMoreButton = this.accountStores.length > LoginComponent.maxInitialButtons;
     if (this.props.showMoreButton) {

--- a/src/components/registration/registration.js
+++ b/src/components/registration/registration.js
@@ -41,10 +41,6 @@ class RegistrationComponent {
     });
   }
 
-  _onlySupportedAccountStores(stores) {
-    return stores.filter((store) => store.authorizeUri);
-  }
-
   toggleMore(e, model) {
     model.props.showMoreButton = false;
     model.props.showButtons = 99;
@@ -58,8 +54,7 @@ class RegistrationComponent {
 
   onViewModelLoaded(data) {
     this.fields = data.form.fields;
-    this.accountStores = this._onlySupportedAccountStores(data.accountStores);
-
+    this.accountStores = data.accountStores;
     this.props.smallButtons = this.accountStores.length > 1;
     this.props.showMoreButton = this.accountStores.length > RegistrationComponent.maxInitialButtons;
     if (this.props.showMoreButton) {

--- a/test/data/user/client-api-user-service.js
+++ b/test/data/user/client-api-user-service.js
@@ -1,0 +1,46 @@
+import chai, { assert } from 'chai';
+import { ClientApiUserService } from '../../../src/data/';
+import utils from '../../../src/utils';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
+
+describe.only('ClientApiUserService', () => {
+  describe('View model transformer (_vieModelTransform)', () => {
+
+    const input = {
+      accountStores: [{
+        authorizeUri: 'foo'
+      }, {
+        foo: 'bar'
+      }]
+    };
+
+    const expectedOutput = {
+      accountStores: [{
+        authorizeUri: 'foo&redirect_uri=' + utils.getCurrentHost()
+      }]
+    };
+
+    let result;
+
+    before((done) => {
+      const userService = new ClientApiUserService();
+      userService._vieModelTransform(input).then((_result) => {
+        result = _result;
+        done();
+      }).catch(done);
+    });
+
+    it('should remove account stores that dont have an authorize uri', () => {
+      assert.equal(result.accountStores.length, 1);
+      assert.isDefined(result.accountStores[0].authorizeUri);
+    });
+
+    it('should set the redirect_uri to the current host (default beahviour)', () => {
+      assert.equal(result.accountStores[0].authorizeUri, expectedOutput.accountStores[0].authorizeUri);
+    });
+  });
+
+  // it('should reomve account stores that dont have an authorize uri')
+});


### PR DESCRIPTION
Fixes #134

I forgot to update the registration view when I added the behavior that uses the current host for the redirect_uri value

This commit centralizes that logic into a view transformer in the ClientApiUserService.  This should also be compatible with whatever we decide for #129, we’ll just need to pass the configuration down to the constructor of the ClientApiUserService