### PR TITLE
Add password strength feedback UI

### DIFF
--- a/src/components/container/container.less
+++ b/src/components/container/container.less
@@ -2,6 +2,7 @@
 @import "../common/animation.less";
 @import "../common/base.less";
 @import "../common/text.less";
+@import "../common/icons.less";
 
 // Shared by login and registration
 @import "../common/social-login.less";

--- a/src/components/form-fields/form-field.html
+++ b/src/components/form-fields/form-field.html
@@ -1,6 +1,6 @@
 <input rv-id="field.name | prefix namePrefix '-'"
        rv-type="field.type"
        rv-name="field.name"
-       rv-value="field.value"
+       rv-value="value"
        rv-placeholder="field.placeholder"
        rv-required="field.required" />

--- a/src/components/form-fields/form-field.js
+++ b/src/components/form-fields/form-field.js
@@ -6,10 +6,12 @@ class FormFieldComponent {
 
   field = {};
   namePrefix = '';
+  value = '';
 
   constructor(data) {
     this.field = data.model;
     this.namePrefix = data.namePrefix;
+    this.value = this.field.value || '';
   }
 }
 

--- a/src/components/form-fields/form-fields.html
+++ b/src/components/form-fields/form-fields.html
@@ -3,4 +3,5 @@
 
   <sp-form-field rv-if="field.type | isnt 'password'" model="field" name-prefix="namePrefix"></sp-form-field>
   <sp-password-form-field rv-if="field.type | is 'password'" model="field" name-prefix="namePrefix"></sp-password-form-field>
+  <sp-password-strength rv-if="field.type | is 'password'" policy="passwordPolicy"></sp-password-strength>
 </div>

--- a/src/components/form-fields/form-fields.html
+++ b/src/components/form-fields/form-fields.html
@@ -2,6 +2,5 @@
   <label rv-for="field.name | prefix namePrefix '-'">{field.label}</label>
 
   <sp-form-field rv-if="field.type | isnt 'password'" model="field" name-prefix="namePrefix"></sp-form-field>
-  <sp-password-form-field rv-if="field.type | is 'password'" model="field" name-prefix="namePrefix"></sp-password-form-field>
-  <sp-password-strength rv-if="field.type | is 'password'" policy="passwordPolicy"></sp-password-strength>
+  <sp-password-form-field rv-if="field.type | is 'password'" policy="passwordPolicy" model="field" name-prefix="namePrefix"></sp-password-form-field>
 </div>

--- a/src/components/form-fields/form-fields.js
+++ b/src/components/form-fields/form-fields.js
@@ -8,10 +8,12 @@ class FormFieldsComponent {
 
   fields = {};
   namePrefix = '';
+  passwordPolicy = {};
 
   constructor(data) {
     this.fields = data.fields;
     this.namePrefix = data.namePrefix;
+    this.passwordPolicy = data.passwordPolicy;
   }
 }
 

--- a/src/components/form-fields/password-form-field.html
+++ b/src/components/form-fields/password-form-field.html
@@ -1,2 +1,3 @@
 <span rv-on-click="togglePasswordVisibility" class="sp-password-toggle">Show</span>
 <sp-form-field model="field" name-prefix="namePrefix"></sp-form-field>
+<sp-password-strength policy="policy"></sp-password-strength>

--- a/src/components/form-fields/password-form-field.html
+++ b/src/components/form-fields/password-form-field.html
@@ -1,3 +1,3 @@
 <span rv-on-click="togglePasswordVisibility" class="sp-password-toggle">Show</span>
-<sp-form-field model="field" name-prefix="namePrefix"></sp-form-field>
-<sp-password-strength policy="policy"></sp-password-strength>
+<sp-form-field model="field" name-prefix="namePrefix" value="value"></sp-form-field>
+<sp-password-strength rv-if="policy" policy="policy" analysis="analysis"></sp-password-strength>

--- a/src/components/form-fields/password-form-field.js
+++ b/src/components/form-fields/password-form-field.js
@@ -1,17 +1,38 @@
 import view from 'html!./password-form-field.html';
 import FormFieldComponent from './form-field';
+import utils from '../../utils';
+import PasswordAnalyzer from '../../data/password-analyzer';
 
 class PasswordFormFieldComponent extends FormFieldComponent {
   static id = 'password-form-field';
   static view = view;
 
   policy = {};
+  value = '';
+  analysis = {};
 
-  constructor(data, el) {
+  constructor(data, el, notificationService) {
     super(data, el);
 
     this.element = el;
     this.policy = data.policy;
+    this.notificationService = notificationService;
+
+    this.notificationService.on('domLoaded', this._onDomLoaded.bind(this));
+  }
+
+  _onDomLoaded() {
+    const inputField = this.element.querySelector('input');
+    if (!inputField) {
+      return;
+    }
+
+    inputField.addEventListener('input', () => this._onInput.bind(this)());
+  }
+
+  _onInput() {
+    let analysis = PasswordAnalyzer.analyze(this.value, this.policy);
+    utils.shallowCopyInPlace(this.analysis, analysis);
   }
 
   togglePasswordVisibility(e, model) {

--- a/src/components/form-fields/password-form-field.js
+++ b/src/components/form-fields/password-form-field.js
@@ -20,10 +20,10 @@ class PasswordFormFieldComponent extends FormFieldComponent {
     this.policy = data.policy;
     this.notificationService = notificationService;
 
-    this.notificationService.on('domLoaded', this._onDomLoaded.bind(this));
+    this.notificationService.on('viewModelLoaded', this._onViewModelLoaded.bind(this));
   }
 
-  _onDomLoaded() {
+  _onViewModelLoaded() {
     const inputField = this.element.querySelector('input');
     if (!inputField) {
       return;

--- a/src/components/form-fields/password-form-field.js
+++ b/src/components/form-fields/password-form-field.js
@@ -5,10 +5,13 @@ class PasswordFormFieldComponent extends FormFieldComponent {
   static id = 'password-form-field';
   static view = view;
 
+  policy = {};
+
   constructor(data, el) {
     super(data, el);
 
     this.element = el;
+    this.policy = data.policy;
   }
 
   togglePasswordVisibility(e, model) {

--- a/src/components/form-fields/password-form-field.js
+++ b/src/components/form-fields/password-form-field.js
@@ -9,7 +9,9 @@ class PasswordFormFieldComponent extends FormFieldComponent {
 
   policy = {};
   value = '';
-  analysis = {};
+  analysis = {
+    dirty: false
+  };
 
   constructor(data, el, notificationService) {
     super(data, el);
@@ -33,6 +35,7 @@ class PasswordFormFieldComponent extends FormFieldComponent {
   _onInput() {
     let analysis = PasswordAnalyzer.analyze(this.value, this.policy);
     utils.shallowCopyInPlace(this.analysis, analysis);
+    this.analysis.dirty = true;
   }
 
   togglePasswordVisibility(e, model) {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,3 +9,4 @@ export ChangePasswordComponent from './change-password/change-password';
 export ForgotPasswordComponent from './forgot-password/forgot-password';
 export SubmitButtonComponent from './submit-button/submit-button';
 export VerifyEmailComponent from './verify-email/verify-email';
+export PasswordStrengthComponent from './password-strength/password-strength';

--- a/src/components/password-strength/password-strength.html
+++ b/src/components/password-strength/password-strength.html
@@ -1,36 +1,36 @@
-<div class="sp-password-strength">
+<div class="sp-password-strength" rv-class-sp-password-strength-dirty="analysis.dirty">
   <p rv-class-sp-password-strength-satisfied="analysis.bothLength">
-    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-length">{analysis.bothLength}</span>
+    <span class="sp-password-strength-feedback"></span>
     {policy.minLength} - {policy.maxLength} characters
   </p>
 
   <p rv-if="policy.minLowerCase | gt 0" rv-class-sp-password-strength-satisfied="analysis.minLowerCase">
-    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-lowercase"></span>
+    <span class="sp-password-strength-feedback"></span>
     At least {policy.minLowerCase} lowercase
   </p>
 
   <p rv-if="policy.minUpperCase | gt 0" rv-class-sp-password-strength-satisfied="analysis.minUpperCase">
-    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-uppercase"></span>
+    <span class="sp-password-strength-feedback"></span>
     At least {policy.minUpperCase} uppercase
   </p>
 
   <p rv-if="policy.minNumeric | gt 0" rv-class-sp-password-strength-satisfied="analysis.minNumeric">
-    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-numeric"></span>
+    <span class="sp-password-strength-feedback"></span>
     At least {policy.minNumeric} number
   </p>
 
   <p rv-if="policy.minSymbol | gt 0" rv-class-sp-password-strength-satisfied="analysis.minSymbol">
-    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-symbol"></span>
+    <span class="sp-password-strength-feedback"></span>
     At least {policy.minSymbol} symbol
   </p>
 
   <p rv-if="policy.minDiacritic | gt 0" rv-class-sp-password-strength-satisfied="analysis.minDiacritic">
-    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-diacritic"></span>
+    <span class="sp-password-strength-feedback"></span>
     At least {policy.minDiacritic} diacritic
   </p>
 
   <p rv-if="policy.preventReuse | gt 0" rv-class-sp-password-strength-satisfied="analysis.preventReuse">
-    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-reuse"></span>
+    <span class="sp-password-strength-feedback"></span>
     Not one of your last {policy.preventReuse} passwords
   </p>
 </div>

--- a/src/components/password-strength/password-strength.html
+++ b/src/components/password-strength/password-strength.html
@@ -1,38 +1,36 @@
-<div rv-if="policy" class="sp-password-strength">
-  <p>
-    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-length"></span>
+<div class="sp-password-strength">
+  <p rv-class-sp-password-strength-satisfied="analysis.bothLength">
+    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-length">{analysis.bothLength}</span>
     {policy.minLength} - {policy.maxLength} characters
   </p>
 
-  <p rv-if="policy.minLowerCase | gt 0">
+  <p rv-if="policy.minLowerCase | gt 0" rv-class-sp-password-strength-satisfied="analysis.minLowerCase">
     <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-lowercase"></span>
     At least {policy.minLowerCase} lowercase
   </p>
 
-  <p rv-if="policy.minUpperCase | gt 0">
+  <p rv-if="policy.minUpperCase | gt 0" rv-class-sp-password-strength-satisfied="analysis.minUpperCase">
     <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-uppercase"></span>
     At least {policy.minUpperCase} uppercase
   </p>
 
-  <p rv-if="policy.minNumeric | gt 0">
+  <p rv-if="policy.minNumeric | gt 0" rv-class-sp-password-strength-satisfied="analysis.minNumeric">
     <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-numeric"></span>
     At least {policy.minNumeric} number
   </p>
 
-  <p rv-if="policy.minSymbol | gt 0">
+  <p rv-if="policy.minSymbol | gt 0" rv-class-sp-password-strength-satisfied="analysis.minSymbol">
     <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-symbol"></span>
     At least {policy.minSymbol} symbol
   </p>
 
-  <p rv-if="policy.minDiacritic | gt 0">
+  <p rv-if="policy.minDiacritic | gt 0" rv-class-sp-password-strength-satisfied="analysis.minDiacritic">
     <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-diacritic"></span>
     At least {policy.minDiacritic} diacritic
   </p>
 
-  <p rv-if="policy.preventReuse | gt 0">
+  <p rv-if="policy.preventReuse | gt 0" rv-class-sp-password-strength-satisfied="analysis.preventReuse">
     <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-reuse"></span>
     Not one of your last {policy.preventReuse} passwords
   </p>
-
-  Password: {props.value}
 </div>

--- a/src/components/password-strength/password-strength.html
+++ b/src/components/password-strength/password-strength.html
@@ -1,0 +1,3 @@
+<div rv-if="policy">
+  Strength: {policy.minLength} - {policy.maxLength}
+</div>

--- a/src/components/password-strength/password-strength.html
+++ b/src/components/password-strength/password-strength.html
@@ -1,3 +1,38 @@
-<div rv-if="policy">
-  Strength: {policy.minLength} - {policy.maxLength}
+<div rv-if="policy" class="sp-password-strength">
+  <p>
+    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-length"></span>
+    {policy.minLength} - {policy.maxLength} characters
+  </p>
+
+  <p rv-if="policy.minLowerCase | gt 0">
+    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-lowercase"></span>
+    At least {policy.minLowerCase} lowercase
+  </p>
+
+  <p rv-if="policy.minUpperCase | gt 0">
+    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-uppercase"></span>
+    At least {policy.minUpperCase} uppercase
+  </p>
+
+  <p rv-if="policy.minNumeric | gt 0">
+    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-numeric"></span>
+    At least {policy.minNumeric} number
+  </p>
+
+  <p rv-if="policy.minSymbol | gt 0">
+    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-symbol"></span>
+    At least {policy.minSymbol} symbol
+  </p>
+
+  <p rv-if="policy.minDiacritic | gt 0">
+    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-diacritic"></span>
+    At least {policy.minDiacritic} diacritic
+  </p>
+
+  <p rv-if="policy.preventReuse | gt 0">
+    <span class="sp-password-strength-feedback" id="sp-password-strength-feedback-reuse"></span>
+    Not one of your last {policy.preventReuse} passwords
+  </p>
+
+  Password: {props.value}
 </div>

--- a/src/components/password-strength/password-strength.js
+++ b/src/components/password-strength/password-strength.js
@@ -1,0 +1,16 @@
+import view from 'html!./password-strength.html';
+import style from '!style-loader!css-loader!less-loader!./password-strength.less';
+
+class PasswordStrengthComponent {
+  static id = 'password-strength';
+  static view = view;
+  static style = style;
+
+  policy = {};
+
+  constructor(data) {
+    this.policy = data.policy;
+  }
+}
+
+export default PasswordStrengthComponent;

--- a/src/components/password-strength/password-strength.js
+++ b/src/components/password-strength/password-strength.js
@@ -7,9 +7,11 @@ class PasswordStrengthComponent {
   static style = style;
 
   policy = {};
+  analysis = {};
 
   constructor(data) {
     this.policy = data.policy;
+    this.analysis = data.analysis;
   }
 }
 

--- a/src/components/password-strength/password-strength.less
+++ b/src/components/password-strength/password-strength.less
@@ -1,4 +1,5 @@
 @import (reference) "../common/variables.less";
+@import (reference) "../common/icons.less";
 
 .sp-password-strength {
   p {
@@ -7,7 +8,28 @@
   }
 
   p.sp-password-strength-satisfied {
-    font-weight: normal;
-    color: @color-disabled;
+    font-weight: normal !important;
+    color: @color-disabled !important;
+  }
+
+  .sp-password-strength-feedback {
+    width: 14px;
+    height: 14px;
+    display: inline-block;
+    margin-right: 2px;
+  }
+
+  .sp-password-strength-satisfied > .sp-password-strength-feedback {
+    .sp-icon-success() !important;
+  }
+}
+
+.sp-password-strength.sp-password-strength-dirty {
+  p {
+    color: darkred;
+  }
+
+  .sp-password-strength-feedback {
+    .sp-icon-warning();
   }
 }

--- a/src/components/password-strength/password-strength.less
+++ b/src/components/password-strength/password-strength.less
@@ -1,0 +1,13 @@
+@import (reference) "../common/variables.less";
+
+.sp-password-strength {
+  p {
+    margin: 0;
+    font-weight: 500;
+  }
+
+  p.sp-password-strength-satisfied {
+    font-weight: normal;
+    color: @color-disabled;
+  }
+}

--- a/src/components/registration/registration.html
+++ b/src/components/registration/registration.html
@@ -23,7 +23,7 @@
     </div>
 
     <fieldset class="sp-form-group">
-      <sp-form-fields fields="fields" name-prefix="'sp-form-registration'"></sp-form-fields>
+      <sp-form-fields fields="fields" password-policy="passwordPolicy" name-prefix="'sp-form-registration'"></sp-form-fields>
     </fieldset>
 
     <div class="sp-error-text" rv-show="state | is 'validation_error'">{error.message}</div>

--- a/src/components/registration/registration.js
+++ b/src/components/registration/registration.js
@@ -20,7 +20,8 @@ class RegistrationComponent {
     isSubmitting: false
   };
 
-  constructor(data) {
+  constructor(data, _, notificationService) {
+    this.notificationService = notificationService;
     this.viewManager = data.viewManager;
     this.userService = data.userService;
     this.autoClose = data.autoClose;
@@ -65,6 +66,7 @@ class RegistrationComponent {
     }
 
     this.state = 'ready';
+    this.notificationService.domLoaded();
   }
 
   onRegistrationComplete(result) {

--- a/src/components/registration/registration.js
+++ b/src/components/registration/registration.js
@@ -9,6 +9,7 @@ class RegistrationComponent {
   fields = [];
   state = 'unknown';
   accountStores = [];
+  passwordPolicy = {};
 
   // This is necessary because currently Rivets cannot bind to top-level primitives
   // (see https://github.com/mikeric/rivets/issues/700#issuecomment-267177540)
@@ -55,6 +56,8 @@ class RegistrationComponent {
   onViewModelLoaded(data) {
     this.fields = data.form.fields;
     this.accountStores = data.accountStores;
+    utils.shallowCopyInPlace(this.passwordPolicy, data.passwordPolicy);
+
     this.props.smallButtons = this.accountStores.length > 1;
     this.props.showMoreButton = this.accountStores.length > RegistrationComponent.maxInitialButtons;
     if (this.props.showMoreButton) {

--- a/src/components/registration/registration.js
+++ b/src/components/registration/registration.js
@@ -66,7 +66,7 @@ class RegistrationComponent {
     }
 
     this.state = 'ready';
-    this.notificationService.domLoaded();
+    this.notificationService.viewModelLoaded();
   }
 
   onRegistrationComplete(result) {

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -2,3 +2,5 @@ export * from './storage';
 export * from './http';
 export * from './user';
 export AuthStrategy from './auth-strategy';
+export NotificationService from './notification-service';
+export PasswordAnalyzer from './password-analyzer';

--- a/src/data/notification-service.js
+++ b/src/data/notification-service.js
@@ -1,0 +1,7 @@
+import EventEmitter from 'events';
+
+class NotificationService extends EventEmitter {
+  domLoaded = (...args) => this.emit('domLoaded', ...args);
+}
+
+export default NotificationService;

--- a/src/data/notification-service.js
+++ b/src/data/notification-service.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 
 class NotificationService extends EventEmitter {
-  domLoaded = (...args) => this.emit('domLoaded', ...args);
+  viewModelLoaded = (...args) => this.emit('viewModelLoaded', ...args);
 }
 
 export default NotificationService;

--- a/src/data/password-analyzer.js
+++ b/src/data/password-analyzer.js
@@ -1,0 +1,91 @@
+class PasswordAnalyzer {
+  static allowedSymbols = [' ', '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '@', '[', '\\', ']', '^', '_', '{', '|', '}', '~', '¡', '§', '©', '«', '¬', '®', '±', 'µ', '¶', '·', '»', '½', '¿', '×', '÷'];
+  static allowedDiacritics = ['À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Æ', 'Ç', 'È', 'É', 'Ê', 'Ë', 'Ì', 'Í', 'Î', 'Ï', 'Ð', 'Ñ', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', 'Ø', 'Ù', 'Ú', 'Û', 'Ü', 'Ý', 'Þ', 'ß', 'à', 'á', 'â', 'ã', 'ä', 'å', 'æ', 'ç', 'è', 'é', 'ê', 'ë', 'ì', 'í', 'î', 'ï', 'ð', 'ñ', 'ò', 'ó', 'ô', 'õ', 'ö', 'ø', 'ù', 'ú', 'û', 'ü', 'ý', 'þ', 'ÿ'];
+
+  static analyze(password, policy) {
+    let analysis = {
+      minLength: false,
+      maxLength: false,
+      bothLength: false,
+      minLowerCase: false,
+      minUpperCase: false,
+      minNumeric: false,
+      minSymbol: false,
+      minDiacritic: false
+    };
+
+    if (!policy['minLength']) {
+      analysis.minLength = true;
+    } else {
+      analysis.minLength = password.length >= policy.minLength;
+    }
+
+    if (!policy['maxLength']) {
+      analysis.maxLength = true;
+    } else {
+      analysis.maxLength = password.length <= policy.maxLength;
+    }
+
+    analysis.bothLength = analysis.minLength && analysis.maxLength;
+
+    if (!policy['minLowerCase']) {
+      analysis.minLowerCase = true;
+    } else {
+      analysis.minLowerCase = PasswordAnalyzer._countLower(password) >= policy.minLowerCase;
+    }
+
+    if (!policy['minUpperCase']) {
+      analysis.minUpperCase = true;
+    } else {
+      analysis.minUpperCase = PasswordAnalyzer._countUpper(password) >= policy.minUpperCase;
+    }
+
+    if (!policy['minNumeric']) {
+      analysis.minNumeric = true;
+    } else {
+      analysis.minNumeric = PasswordAnalyzer._countDigits(password) >= policy.minNumeric;
+    }
+
+    if (!policy['minSymbol']) {
+      analysis.minSymbol = true;
+    } else {
+      analysis.minSymbol =
+        PasswordAnalyzer._countOccurrencesOfAny(password, PasswordAnalyzer.allowedSymbols) >= policy.minSymbol;
+    }
+
+    if (!policy['minDiacritic']) {
+      analysis.minDiacritic = true;
+    } else {
+      analysis.minDiacritic =
+        PasswordAnalyzer._countOccurrencesOfAny(password, PasswordAnalyzer.allowedDiacritics) >= policy.minDiacritic;
+    }
+
+    return analysis;
+  }
+
+  static _countLower = (str) => PasswordAnalyzer._countBetween(str, 'a', 'z');
+
+  static _countUpper = (str) => PasswordAnalyzer._countBetween(str, 'A', 'Z');
+
+  static _countDigits = (str) => PasswordAnalyzer._countBetween(str, '0', '9');
+
+  static _countBetween(str, start, end) {
+    var count = 0;
+    for (var char of str) {
+      if (char >= start && char <= end) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  static _countOccurrencesOfAny(str, chars) {
+    var count = 0;
+    for (var char of chars) {
+      count += str.split(char).length - 1;
+    }
+    return count;
+  }
+}
+
+export default PasswordAnalyzer;

--- a/src/utils.js
+++ b/src/utils.js
@@ -256,6 +256,25 @@ class Utils {
 
     return result;
   }
+
+  shallowCopyInPlace(original, newObj) {
+    if (!original) {
+      throw new Error('Original object must exist');
+    }
+
+    if (!newObj) {
+      return;
+    }
+
+    const keys = Object.keys(newObj);
+    if (!keys.length) {
+      return;
+    }
+
+    for (let prop of keys) {
+      original[prop] = newObj[prop];
+    }
+  }
 }
 
 export default new Utils();

--- a/src/view-manager.js
+++ b/src/view-manager.js
@@ -18,6 +18,8 @@ import {
   PasswordStrengthComponent,
 } from './components';
 
+import { NotificationService } from './data';
+
 class ViewManager {
   static defaultComponents = {
     [ContainerComponent.id]: {
@@ -68,8 +70,10 @@ class ViewManager {
 
   constructor(prefix, userService, templates, container) {
     this.userService = userService;
+    this.notificationService = new NotificationService();
     this.prefix = prefix;
     this.templates = templates;
+
     this._initializeRivets(extend(ViewManager.defaultComponents));
     this.setContainer(container);
   }
@@ -90,7 +94,7 @@ class ViewManager {
 
       Rivets.components[this.prefix + '-' + id] = {
         template: viewFunction,
-        initialize: (el, d) => new data.component(d, el)
+        initialize: (el, d) => new data.component(d, el, this.notificationService)
       };
     }
   }

--- a/src/view-manager.js
+++ b/src/view-manager.js
@@ -14,7 +14,8 @@ import {
   PasswordFormFieldComponent,
   RegistrationComponent,
   SubmitButtonComponent,
-  VerifyEmailComponent
+  VerifyEmailComponent,
+  PasswordStrengthComponent,
 } from './components';
 
 class ViewManager {
@@ -58,7 +59,11 @@ class ViewManager {
     [VerifyEmailComponent.id]: {
       component: VerifyEmailComponent,
       view: () => VerifyEmailComponent.view
-    }
+    },
+    [PasswordStrengthComponent.id]: {
+      component: PasswordStrengthComponent,
+      view: () => PasswordStrengthComponent.view
+    },
   };
 
   constructor(prefix, userService, templates, container) {

--- a/test/data/password-analyzer-test.js
+++ b/test/data/password-analyzer-test.js
@@ -1,0 +1,124 @@
+import { assert } from 'chai';
+import PasswordAnalyzer from '../../src/data/password-analyzer';
+
+describe('data/PasswordAnalyzer', () => {
+  describe('validates', () => {
+    it('above minimum length', () => {
+      var result = PasswordAnalyzer.analyze('12345', {
+        minLength: 4
+      });
+      assert.isTrue(result.minLength);
+      assert.isTrue(result.bothLength);
+    });
+
+    it('below maximum length', () => {
+      var result = PasswordAnalyzer.analyze('12345', {
+        maxLength: 6
+      });
+      assert.isTrue(result.maxLength);
+      assert.isTrue(result.bothLength);
+    });
+
+    it('has enough lowercase', () => {
+      var result = PasswordAnalyzer.analyze('Abcdef', {
+        minLowerCase: 5
+      });
+      assert.isTrue(result.minLowerCase);
+    });
+
+    it('has enough uppercase', () => {
+      var result = PasswordAnalyzer.analyze('aBCDEF', {
+        minUpperCase: 5
+      });
+      assert.isTrue(result.minUpperCase);
+    });
+
+    it('has enough digits', () => {
+      var result = PasswordAnalyzer.analyze('1234', {
+        minNumeric: 3
+      });
+      assert.isTrue(result.minNumeric);
+    });
+
+    it('has enough (mixed) digits', () => {
+      var result = PasswordAnalyzer.analyze('ab1c2d3f4', {
+        minNumeric: 3
+      });
+      assert.isTrue(result.minNumeric);
+    });
+
+    it('has enough symbols', () => {
+      var result = PasswordAnalyzer.analyze('foo=bar!*', {
+        minSymbol: 3
+      });
+      assert.isTrue(result.minSymbol);
+    });
+
+    it('has enough diacritics', () => {
+      var result = PasswordAnalyzer.analyze('foöbåþ', {
+        minDiacritic: 3
+      });
+      assert.isTrue(result.minDiacritic);
+    });
+  });
+
+  describe('invalidates', () => {
+    it('below minimum length', () => {
+      var result = PasswordAnalyzer.analyze('foo', {
+        minLength: 4
+      });
+      assert.isFalse(result.minLength);
+      assert.isFalse(result.bothLength);
+    });
+
+    it('above maximum length', () => {
+      var result = PasswordAnalyzer.analyze('foobar', {
+        maxLength: 4
+      });
+      assert.isFalse(result.maxLength);
+      assert.isFalse(result.bothLength);
+    });
+
+    it('too few lowercase', () => {
+      var result = PasswordAnalyzer.analyze('AAa', {
+        minLowerCase: 5
+      });
+      assert.isFalse(result.minLowerCase);
+    });
+
+    it('digits intead of lowercase', () => {
+      var result = PasswordAnalyzer.analyze('123', {
+        minLowerCase: 1
+      });
+      assert.isFalse(result.minLowerCase);
+    });
+
+    it('too few uppercase', () => {
+      var result = PasswordAnalyzer.analyze('AAa', {
+        minUpperCase: 5
+      });
+      assert.isFalse(result.minUpperCase);
+    });
+
+    it('too few digits', () => {
+      var result = PasswordAnalyzer.analyze('123', {
+        minNumeric: 4
+      });
+      assert.isFalse(result.minNumeric);
+    });
+
+    it('too few symbols', () => {
+      var result = PasswordAnalyzer.analyze('foo=bar!*', {
+        minSymbol: 4
+      });
+      assert.isFalse(result.minSymbol);
+    });
+
+    it('too few diacritics', () => {
+      var result = PasswordAnalyzer.analyze('foöbåþ', {
+        minDiacritic: 4
+      });
+      assert.isFalse(result.minDiacritic);
+    });
+  });
+});

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -417,4 +417,36 @@ describe('utils', () => {
       });
     });
   });
+
+  describe('.shallowCopyInPlace(original, newObj)', () => {
+    describe('when the original object is empty', () => {
+      it('input = undefined should have no effect', () => {
+        let original = {};
+        utils.shallowCopyInPlace(original);
+        assert.deepEqual(original, {});
+      });
+
+      it('input = null should have no effect', () => {
+        let original = {};
+        utils.shallowCopyInPlace(original, null);
+        assert.deepEqual(original, {});
+      });
+
+      it('should add properties', () => {
+        let original = {};
+        utils.shallowCopyInPlace(original, { foo: 1, bar: 2 });
+        assert.equal(original.foo, 1);
+        assert.equal(original.bar, 2);
+      });
+    });
+
+    describe('when the original object has properties', () => {
+      it('should update properties', () => {
+        let original = { foo: 'bar' };
+        utils.shallowCopyInPlace(original, { foo: 1, baz: 'qux' });
+        assert.equal(original.foo, 1);
+        assert.equal(original.baz, 'qux');
+      });
+    });
+  });
 });


### PR DESCRIPTION
I built the password strength feedback UI stuff from the mockups. The rules are pulled from the `passwordPolicy` model of the `/register` endpoint.

@alexdahl - the icons you sent me on Slack actually don't match up with the Invision mockups. Not a big deal, this isn't super high prio. :)

I'm not sure if it makes sense to hide this completely before the user starts typing, and have it slide out?

Here's what it looks like:

<img src="http://g.recordit.co/rqdlmWRm4U.gif"/>

Closes #148