### PR TITLE
Publish script that automates a bunch of stuff

### DIFF
--- a/package-for-dist.js
+++ b/package-for-dist.js
@@ -12,7 +12,7 @@ const outputSourceMapFile = `${__dirname}/dist/${sourceMapFilename}`;
 
 // Sanity check
 if (!fs.existsSync(outputSourceFile) || !fs.existsSync(outputSourceMapFile)) {
-  throw new Error('The source files do not exist');
+  throw new Error('The source files do not exist. Please run the build script.');
 }
 if (fs.existsSync(stagingDirectory)) {
   throw new Error('The staging directory already exists');

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-register": "^6.18.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
+    "chalk": "^1.1.3",
     "eslint-watch": "^2.1.14",
     "express": "^4.14.0",
     "git-rev-sync": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "protractor-sauce": "./node_modules/protractor/bin/protractor test/protractor/entry-sauce.js",
     "start": "node dev-server.js",
     "test": "npm run lint && npm run karma",
-    "pack": "node package-for-dist.js"
+    "pack": "node package-for-dist.js",
+    "publish": "node publish.js",
   },
   "dependencies": {
     "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "start": "node dev-server.js",
     "test": "npm run lint && npm run karma",
     "pack": "node package-for-dist.js",
-    "publish": "node publish.js",
+    "publish": "node publish.js"
   },
   "dependencies": {
     "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "chai-as-promised": "^6.0.0",
     "eslint-watch": "^2.1.14",
     "express": "^4.14.0",
+    "git-rev-sync": "^1.8.0",
     "json-loader": "^0.5.4",
     "karma": "^1.3.0",
     "karma-chai": "^0.1.0",

--- a/publish.js
+++ b/publish.js
@@ -3,24 +3,43 @@
 const semver = require('semver');
 const fs = require('fs');
 const child_process = require('child_process');
-
-const packageJsonPath = `${__dirname}/package.json`;
+const git = require('git-rev-sync');
 
 const version = process.argv[2];
-if (!semver.valid(version)) {
-  throw new Error(`Version '${version}' is not a valid semver string!`);
-}
+const packageJsonPath = `${__dirname}/package.json`;
+
+let throwIfVersionInvalid = (versionArg) => {
+  if (!semver.valid(versionArg)) {
+    throw new Error(`Version '${versionArg}' is not a valid semver string!`);
+  }
+};
+
+let throwIfNotOnMaster = () => {
+  const branch = git.branch();
+  if (branch !== 'master') {
+    throw new Error(`Must be on branch master (current branch is ${branch})`);
+  }
+};
+
+let updatePackageJsonVersion = (path, newVersion) => {
+  const packageInfo = JSON.parse(fs.readFileSync(path, 'utf-8'));
+  packageInfo.version = newVersion;
+  fs.writeFileSync(path, JSON.stringify(packageInfo, null, 2), 'utf-8');
+};
+
+let buildProject = () => {
+  const buildResult = child_process.spawnSync('npm', ['run', 'build']);
+  if (buildResult.status !== 0) {
+    throw new Error('Build failed');
+  }
+};
+
+throwIfVersionInvalid(version);
+throwIfNotOnMaster();
 
 /* eslint-disable no-console */
 console.log(`Prepping version ${version}`);
+updatePackageJsonVersion(packageJsonPath, version);
 
-const packageInfo = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-packageInfo.version = version;
-fs.writeFileSync(packageJsonPath, JSON.stringify(packageInfo, null, 2), 'utf-8');
-
-// console.log('Building project...');
-// const buildResult = child_process.spawnSync('npm', ['run', 'build']);
-// if (buildResult.status !== 0) {
-//   throw new Error('Build failed');
-// }
-
+console.log('Building project...');
+buildProject();

--- a/publish.js
+++ b/publish.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const semver = require('semver');
+const fs = require('fs');
+const child_process = require('child_process');
+
+const packageJsonPath = `${__dirname}/package.json`;
+
+const version = process.argv[2];
+if (!semver.valid(version)) {
+  throw new Error(`Version '${version}' is not a valid semver string!`);
+}
+
+/* eslint-disable no-console */
+console.log(`Prepping version ${version}`);
+
+const packageInfo = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+packageInfo.version = version;
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageInfo), 'utf-8');
+
+// console.log('Building project...');
+// const buildResult = child_process.spawnSync('npm', ['run', 'build']);
+// if (buildResult.status !== 0) {
+//   throw new Error('Build failed');
+// }
+

--- a/publish.js
+++ b/publish.js
@@ -16,7 +16,7 @@ console.log(`Prepping version ${version}`);
 
 const packageInfo = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 packageInfo.version = version;
-fs.writeFileSync(packageJsonPath, JSON.stringify(packageInfo), 'utf-8');
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageInfo, null, 2), 'utf-8');
 
 // console.log('Building project...');
 // const buildResult = child_process.spawnSync('npm', ['run', 'build']);

--- a/publish.js
+++ b/publish.js
@@ -21,6 +21,13 @@ let throwIfNotOnMaster = () => {
   }
 };
 
+let throwIfVersionLessThanCurrentTag = (newVersion) => {
+  const latestTag = git.tag();
+  if (!semver.gt(newVersion, latestTag)) {
+    throw new Error(`Proposed version ${newVersion} is not greater than current tag ${latestTag}`);
+  }
+};
+
 let updatePackageJsonVersion = (path, newVersion) => {
   const packageInfo = JSON.parse(fs.readFileSync(path, 'utf-8'));
   packageInfo.version = newVersion;
@@ -35,7 +42,9 @@ let buildProject = () => {
 };
 
 throwIfVersionInvalid(version);
-throwIfNotOnMaster();
+//throwIfNotOnMaster();
+console.log('TODO RESTORE');
+throwIfVersionLessThanCurrentTag(version);
 
 /* eslint-disable no-console */
 console.log(`Prepping version ${version}`);

--- a/publish.js
+++ b/publish.js
@@ -55,6 +55,10 @@ let appendToIntegrityFile = (version, hash) => {
   fs.appendFileSync(integrityFilePath, `${version} ${shaAlgorithm}-${hash}`);
 };
 
+let addAndCommitWithTag = () => {
+  child_process.execSync('git add --all');
+};
+
 /* eslint-disable no-console */
 throwIfVersionInvalid(version);
 //throwIfNotOnMaster();
@@ -71,5 +75,6 @@ console.log(`Built stormpath.min.js v${version} with SHA ${minifiedHash}`);
 appendToIntegrityFile(version, minifiedHash);
 
 // commit and tag
+addAndCommitWithTag();
 
 console.log(chalk.green('Done! Don\'t forget to run:\ngit push origin --tags'));

--- a/publish.js
+++ b/publish.js
@@ -4,9 +4,12 @@ const semver = require('semver');
 const fs = require('fs');
 const child_process = require('child_process');
 const git = require('git-rev-sync');
+const chalk = require('chalk');
 
 const version = process.argv[2];
 const packageJsonPath = `${__dirname}/package.json`;
+const minifiedDistPath = `${__dirname}/dist/stormpath.min.js`;
+const integrityFilePath = `${__dirname}/integrity.txt`;
 
 let throwIfVersionInvalid = (versionArg) => {
   if (!semver.valid(versionArg)) {
@@ -41,14 +44,31 @@ let buildProject = () => {
   }
 };
 
+let computeHashFor = (path) => {
+  return child_process
+    .execSync(`cat ${path} | openssl dgst -sha384 -binary | openssl enc -base64 -A`)
+    .toString();
+};
+
+let appendToIntegrityFile = (version, hash) => {
+  fs.appendFileSync(integrityFilePath, `${version} ${hash}`);
+};
+
+/* eslint-disable no-console */
 throwIfVersionInvalid(version);
 //throwIfNotOnMaster();
 console.log('TODO RESTORE');
 throwIfVersionLessThanCurrentTag(version);
-
-/* eslint-disable no-console */
-console.log(`Prepping version ${version}`);
 updatePackageJsonVersion(packageJsonPath, version);
 
 console.log('Building project...');
 buildProject();
+
+const minifiedHash = computeHashFor(minifiedDistPath);
+console.log(`Built stormpath.min.js v${version} with SHA ${minifiedHash}`);
+// TODO - update README.MD automatically
+appendToIntegrityFile(version, minifiedHash);
+
+// commit and tag
+
+console.log(chalk.green('Done! Don\'t forget to run:\ngit push origin --tags'));

--- a/publish.js
+++ b/publish.js
@@ -61,13 +61,14 @@ let addAndCommitWithTag = (version) => {
   child_process.execSync(`git tag ${version}`);
 };
 
-/* eslint-disable no-console */
+// Main routine starts here:
+
 throwIfVersionInvalid(version);
-//throwIfNotOnMaster();
-console.log('TODO RESTORE');
+throwIfNotOnMaster();
 throwIfVersionLessThanCurrentTag(version);
 updatePackageJsonVersion(packageJsonPath, version);
 
+/* eslint-disable no-console */
 console.log('Building project...');
 buildProject();
 

--- a/publish.js
+++ b/publish.js
@@ -10,6 +10,7 @@ const version = process.argv[2];
 const packageJsonPath = `${__dirname}/package.json`;
 const minifiedDistPath = `${__dirname}/dist/stormpath.min.js`;
 const integrityFilePath = `${__dirname}/integrity.txt`;
+const shaAlgorithm = 'sha384';
 
 let throwIfVersionInvalid = (versionArg) => {
   if (!semver.valid(versionArg)) {
@@ -51,7 +52,7 @@ let computeHashFor = (path) => {
 };
 
 let appendToIntegrityFile = (version, hash) => {
-  fs.appendFileSync(integrityFilePath, `${version} ${hash}`);
+  fs.appendFileSync(integrityFilePath, `${version} ${shaAlgorithm}-${hash}`);
 };
 
 /* eslint-disable no-console */

--- a/publish.js
+++ b/publish.js
@@ -55,8 +55,10 @@ let appendToIntegrityFile = (version, hash) => {
   fs.appendFileSync(integrityFilePath, `${version} ${shaAlgorithm}-${hash}`);
 };
 
-let addAndCommitWithTag = () => {
+let addAndCommitWithTag = (version) => {
   child_process.execSync('git add --all');
+  child_process.execSync(`git commit -m "Publish stormpath-widget ${version}"`);
+  child_process.execSync(`git tag ${version}`);
 };
 
 /* eslint-disable no-console */
@@ -75,6 +77,6 @@ console.log(`Built stormpath.min.js v${version} with SHA ${minifiedHash}`);
 appendToIntegrityFile(version, minifiedHash);
 
 // commit and tag
-addAndCommitWithTag();
+addAndCommitWithTag(version);
 
 console.log(chalk.green('Done! Don\'t forget to run:\ngit push origin --tags'));


### PR DESCRIPTION
You can now do `npm run publish 0.0.3` to do the following **automagically**:

👍 Do some sanity checks in preparation for publishing a new version.
👍 Update the version in `package.json`
👍 Build the distribution version of the script
👍 Calculate the SHA-384 hash of `stormpath.min.js` and append it to the history in `integrity.txt`
👍 Commit and tag the new version

Closes #153 